### PR TITLE
PEN-710: Add ignore_methods to skip tracing for specified methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog for the gruf-zipkin gem.
 
+h3. Pending Release
+
+- Add ignore_methods as an option to server interceptor
+
 h3. 1.0.0
 
 - Support for gruf 2.0.0

--- a/lib/gruf/lightstep/server_interceptor.rb
+++ b/lib/gruf/lightstep/server_interceptor.rb
@@ -23,6 +23,8 @@ module Gruf
       # Handle the gruf around hook and trace sampled requests
       #
       def call(&_block)
+        return yield if options.fetch(:ignore_methods, []).include?(request.method_name)
+
         result = nil
 
         tracer = ::Bigcommerce::Lightstep::Tracer.instance


### PR DESCRIPTION
Adds `ignore_methods` which can be used to ignore lightstep tracing for specified grpc methods.

----

@pedelman @mattolson @bigcommerce/platform-engineering 