### PR TITLE
PEN-766: Exclude client validation errors from span error tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf-zipkin gem.
 
 h3. Pending Release
 
+h3. 1.1.0
+
+- Exclude client validation errors from being "errors"
+
 h3. 1.0.3
 
 - Ensure gRPC requests are always the root span

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rspec', '~> 3.7'
   spec.add_development_dependency 'pry'
 
   spec.add_runtime_dependency 'lightstep', '~> 0.11'


### PR DESCRIPTION
This makes it so only HTTP 500-style errors are tagged as errors in the lightstep trace.

----

@bigcommerce/platform-engineering @pedelman @gbanuel 