### PR TITLE
Add option to whitelist request params to lightstep as span tags

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -9,6 +9,6 @@ then
 
 elif [ "$TEST_GROUP"  == "1" ]
 then
-  # bundle exec rspec
+  bundle exec rspec
   echo 0
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-zipkin gem.
 
 h3. Pending Release
 
+- Add option to whitelist request params to lightstep as span tags
+
 h3. 1.1.1
 
 - Bump bc-lightstep-ruby to 1.1.5

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Gruf.configure do |c|
 end
 ```
 
+It comes with a few more options as well:
+
+| Option | Description | Default |
+| ------ | ----------- | ------- |
+| whitelist | An array of parameter key names to log to lightstep. E.g. `[uuid kind]` | `[]` |
+| ignore_methods | An array of method names to ignore from logging. E.g. `['namespace.health.check']` | `[]` |
+
+It's important to maintain a safe whitelist should you decide to log parameters; gruf does no
+parameter sanitization on its own. We also recommend do not whitelist parameters that may contain
+very large values (such as binary or json data).
+
 ### Client Interceptors
 
 To automatically propagate the trace context outbound, in your Gruf clients, pass the client interceptor

--- a/spec/support/request.rb
+++ b/spec/support/request.rb
@@ -13,7 +13,19 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-class ThingRequest; end
+class ThingRequest
+  attr_reader :uuid, :kind
+
+  def initialize(uuid, kind)
+    @uuid = uuid
+    @kind = kind
+  end
+
+  def to_h
+    {uuid: uuid, kind: kind}
+  end
+end
+
 class ThingService; end
 
 module Gruf
@@ -32,7 +44,7 @@ module Gruf
       end
 
       def grpc_request
-        ThingRequest.new
+        ThingRequest.new('some uuid', 'some kind')
       end
     end
   end


### PR DESCRIPTION
This PR exposes a whitelist option to whitelist a set of request params which will be set as span tags to lightstep

@splittingred @mattolson @pedelman 