### PR TITLE
Handle Non-GRPC exceptions

### DIFF
--- a/lib/gruf/lightstep/configuration.rb
+++ b/lib/gruf/lightstep/configuration.rb
@@ -21,6 +21,7 @@ module Gruf
     #
     module Configuration
       VALID_CONFIG_KEYS = {
+        default_error_code: GRPC::Core::StatusCodes::INTERNAL
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys

--- a/lib/gruf/lightstep/server_interceptor.rb
+++ b/lib/gruf/lightstep/server_interceptor.rb
@@ -46,7 +46,7 @@ module Gruf
           rescue StandardError => e
             span.set_tag('error', true) if error?(e)
             span.set_tag('grpc.error', true)
-            span.set_tag('grpc.error_code', e.code)
+            span.set_tag('grpc.error_code', code_for(e))
             span.set_tag('grpc.error_class', e.class)
             raise # passthrough, we just want the annotations
           end
@@ -55,6 +55,14 @@ module Gruf
       end
 
       private
+
+      ##
+      # @param [StandardError]
+      # @return [Number] that maps to one of the GRCP::Core::StatusCodes or Gruf::Lightstep.default_error_code
+      #
+      def code_for(e)
+        e.respond_to?(:code) ? e.code : Gruf::Lightstep.default_error_code
+      end
 
       ##
       # @return [Gruf::Lightstep::Method]

--- a/spec/gruf/lightstep_spec.rb
+++ b/spec/gruf/lightstep_spec.rb
@@ -1,0 +1,52 @@
+# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+require 'spec_helper'
+
+describe Gruf::Lightstep do
+  describe '.configure' do
+    let(:configuration) { described_class  }
+    subject(:configure) { configuration.configure(&block) }
+
+    before { described_class.reset }
+    after { described_class.reset }
+
+    context 'when no values are overridden' do
+      let(:block) { Proc.new { |config|  } }
+
+      it 'has default values' do
+        configure
+
+        expect(configuration.default_error_code).to be(GRPC::Core::StatusCodes::INTERNAL)
+        expect(configuration.options).to eq(default_error_code: GRPC::Core::StatusCodes::INTERNAL)
+      end
+    end
+
+    context 'when values are overridden' do
+      let(:block) do
+        Proc.new { |config|
+          config.default_error_code = GRPC::Core::StatusCodes::UNKNOWN
+        }
+      end
+
+      it 'has overridden values' do
+        configure
+
+        expect(configuration.default_error_code).to be(GRPC::Core::StatusCodes::UNKNOWN)
+        expect(configuration.options).to eq(default_error_code: GRPC::Core::StatusCodes::UNKNOWN)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes issue when gRPC services raise `StandardError`s that do not have a `code` property, e.g. `NoMethodError`.

When the interceptor encounters a `StandardError` it raises a different error and halts tracing:
```
undefined method `code' for #<NoMethodError: undefined method `call' for nil:NilClass>
```