### PR TITLE
Add `frozen_string_literal: true` to all files, deprecate ruby 2.2

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 AllCops:
+  TargetRubyVersion: 2.4
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -9,38 +10,18 @@ AllCops:
     - Rakefile
     - gruf-lightstep.gemspec
 
+# Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:
   Enabled: false
 
+# server interceptors have higher ABC
 Metrics/AbcSize:
-  Max: 147
+  Max: 50
 
-Metrics/BlockNesting:
-  Max: 4
-
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 406
-
-Metrics/CyclomaticComplexity:
-  Max: 24
-
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes.
-# URISchemes: http, https
+# This cop conflicts with other cops
 Metrics/LineLength:
   Enabled: false
 
-# Offense count: 63
-# Configuration parameters: CountComments.
+# server interceptor requires this length
 Metrics/MethodLength:
-  Max: 88
-
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Max: 1000
-
-Performance/RedundantBlockCall:
-  Enabled: false
-
-Style/PercentLiteralDelimiters:
-  Enabled: false
+  Max: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-zipkin gem.
 
 h3. Pending Release
 
+- Add `frozen_string_literal: true` to all files
+- Deprecate ruby 2.2 support
+
 h3. 1.1.3
 
 - Bump bc-lightstep-ruby to 1.2.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -18,10 +20,10 @@ source 'https://rubygems.org'
 gem 'gruf', '~> 2.4'
 
 group :development do
-  gem 'bundler-audit'
-  gem 'rspec', '~> 3.8'
+  gem 'bundler-audit',         '~> 0.6'
+  gem 'rspec',                 '~> 3.8'
   gem 'rspec_junit_formatter', '~> 0.4.1'
-  gem 'rubocop'
+  gem 'rubocop',               '~> 0.68'
   gem 'simplecov', require: false
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/lightstep.rb
+++ b/lib/gruf/lightstep.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/lightstep/client_interceptor.rb
+++ b/lib/gruf/lightstep/client_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -42,7 +44,7 @@ module Gruf
         return unless tracer
 
         span = tracer.active_span
-        return unless span && span.is_a?(::LightStep::Span)
+        return unless span&.is_a?(::LightStep::Span)
 
         span
       end

--- a/lib/gruf/lightstep/configuration.rb
+++ b/lib/gruf/lightstep/configuration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/lightstep/headers.rb
+++ b/lib/gruf/lightstep/headers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -25,11 +27,11 @@ module Gruf
       # @property [Hash<Symbol|Array<String>>] Hash mapping of metadata keys
       #
       OT_KEYS = {
-        parent_span_id: %w(ot-tracer-parentspanid OT-Tracer-ParentSpanId HTTP_X_OT_TRACER_PARENTSPANID),
-        span_id: %w(ot-tracer-spanid OT-Tracer-SpanId HTTP_X_OT_TRACER_SPANID),
-        trace_id: %w(ot-tracer-traceid OT-Tracer-TraceId HTTP_X_OT_TRACER_TRACEID),
-        sampled: %w(ot-tracer-sampled OT-Tracer-Sampled HTTP_X_OT_TRACER_SAMPLED),
-        flags: %w(ot-tracer-flags OT-Tracer-Flags HTTP_X_OT_TRACER_FLAGS)
+        parent_span_id: %w[ot-tracer-parentspanid OT-Tracer-ParentSpanId HTTP_X_OT_TRACER_PARENTSPANID],
+        span_id: %w[ot-tracer-spanid OT-Tracer-SpanId HTTP_X_OT_TRACER_SPANID],
+        trace_id: %w[ot-tracer-traceid OT-Tracer-TraceId HTTP_X_OT_TRACER_TRACEID],
+        sampled: %w[ot-tracer-sampled OT-Tracer-Sampled HTTP_X_OT_TRACER_SAMPLED],
+        flags: %w[ot-tracer-flags OT-Tracer-Flags HTTP_X_OT_TRACER_FLAGS]
       }.freeze
 
       delegate :has_key?, :key?, to: :metadata

--- a/lib/gruf/lightstep/method.rb
+++ b/lib/gruf/lightstep/method.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/lib/gruf/lightstep/server_interceptor.rb
+++ b/lib/gruf/lightstep/server_interceptor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -91,7 +93,7 @@ module Gruf
       # @return [Array]
       #
       def error_classes
-        options.fetch(:error_classes, %w(GRPC::Unknown GRPC::Internal GRPC::DataLoss GRPC::FailedPrecondition GRPC::Unavailable GRPC::DeadlineExceeded GRPC::Cancelled))
+        options.fetch(:error_classes, %w[GRPC::Unknown GRPC::Internal GRPC::DataLoss GRPC::FailedPrecondition GRPC::Unavailable GRPC::DeadlineExceeded GRPC::Cancelled])
       end
     end
   end

--- a/lib/gruf/lightstep/version.rb
+++ b/lib/gruf/lightstep/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
@@ -15,6 +17,6 @@
 #
 module Gruf
   module Lightstep
-    VERSION = '1.1.4.pre'.freeze
+    VERSION = '1.1.4.pre'
   end
 end


### PR DESCRIPTION
## What?

Adds frozen_string_literal: true to the top of all files, which should ease the transition of the gem to Ruby 3.0, and ensure we're in parity with Ruby community conventions.

Also, bump rubocop to target a minimum version of Ruby 2.4 going forward, and fix appropriate cop-flagged issues.

This officially deprecates Ruby 2.2 support for this gem.

----

@bigcommerce/ruby @bigcommerce/platform-engineering @bigcommerce/oss-maintainers 