### PR TITLE
chore(platform): PEN-1713 - Bump bc-lightstep-ruby dep, Ruby 2.6+ only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,6 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.6"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.5"
   ruby_2_6:
     <<: *ruby_env
     parameters:
@@ -86,7 +74,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +84,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +94,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +102,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -7,8 +7,6 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
     - log/**/*
-    - Rakefile
-    - gruf-lightstep.gemspec
 
 # Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:
@@ -19,9 +17,31 @@ Metrics/AbcSize:
   Max: 50
 
 # This cop conflicts with other cops
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 # server interceptor requires this length
 Metrics/MethodLength:
   Max: 30
+
+# New rubocop-required cops
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,60 +1,65 @@
-Changelog for the gruf-zipkin gem.
+Changelog for the gruf-lightstep gem.
 
-h3. Pending Release
+### Pending Release
 
-h3. 1.2.1
+- Bump Ruby requirement to 2.6+
+- Bump bc-lightstep-ruby dependency to 2.0+
+- Explicitly declare gruf requirement in gemspec
+- Explicitly declare development deps for gem
+
+###  1.2.1
 
 - Ensure boundary span has `span.kind` set
 
-h3. 1.2.0
+### 1.2.0
 
 - Add `frozen_string_literal: true` to all files
 - Deprecate ruby 2.2 support
 
-h3. 1.1.3
+### 1.1.3
 
 - Bump bc-lightstep-ruby to 1.2.0
 
-h3. 1.1.2
+### 1.1.2
 
 - First OSS release
 - Explicitly require bc-lightstep-ruby dependency
 - Add option to whitelist request params to lightstep as span tags
 
-h3. 1.1.1
+### 1.1.1
 
 - Bump bc-lightstep-ruby to 1.1.5
 - Bump gruf minimum version to 2.4
 
-h3. 1.1.0
+### 1.1.0
 
 - Exclude client validation errors from being "errors"
 
-h3. 1.0.3
+### 1.0.3
 
 - Ensure gRPC requests are always the root span
 
-h3. 1.0.2
+### 1.0.2
 
 - Add ignore_methods as an option to server interceptor
 - Standardize span tags according to BC spec
 
-h3. 1.0.0
+### 1.0.0
 
 - Support for gruf 2.0.0
 
-h3. 0.10.3
+### 0.10.3
 
 - Update to 0.10.3, add rubocop+bundler-audit
 
-h3. 0.10.2
+### 0.10.2
 
 - Updated license to MIT
 
-h3. 0.10.1
+### 0.10.1
 
 - Handle case when tracer is not yet initialized before trace executes
 
-h3. 0.10.0
+### 0.10.0
 
 - Initial public release

--- a/Gemfile
+++ b/Gemfile
@@ -17,14 +17,4 @@
 #
 source 'https://rubygems.org'
 
-gem 'gruf', '~> 2.4'
-
-group :development do
-  gem 'bundler-audit',         '~> 0.6'
-  gem 'rspec',                 '~> 3.8'
-  gem 'rspec_junit_formatter', '~> 0.4.1'
-  gem 'rubocop',               '~> 0.68'
-  gem 'simplecov', require: false
-end
-
 gemspec

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$:.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
 require 'gruf/lightstep/version'
 
 Gem::Specification.new do |spec|
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Shaun McCormick']
   spec.email         = ['shaun.mccormick@bigcommerce.com']
 
-  spec.summary       = %q{Plugin for lightstep tracing for gruf}
+  spec.summary       = 'Plugin for lightstep tracing for gruf'
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/bigcommerce/gruf-lightstep'
   spec.license       = 'MIT'
@@ -32,10 +32,17 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-lightstep.gemspec']
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'rake', '>= 12.3'
-  spec.add_development_dependency 'rspec', '~> 3.7'
-  spec.add_development_dependency 'pry', '>= 0.13'
+  spec.required_ruby_version = '~> 2.6'
 
-  spec.add_runtime_dependency 'bc-lightstep-ruby', '~> 1.2'
+  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler-audit', '~> 0.6'
+  spec.add_development_dependency 'pry', '>= 0.13'
+  spec.add_development_dependency 'rake', '>= 12.0'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
+  spec.add_development_dependency 'rubocop', '~> 0.82'
+  spec.add_development_dependency 'simplecov', '~> 0.15'
+
+  spec.add_runtime_dependency 'bc-lightstep-ruby', '~> 2.0'
+  spec.add_runtime_dependency 'gruf', '>= 2.4', '< 3'
 end

--- a/lib/gruf/lightstep/method.rb
+++ b/lib/gruf/lightstep/method.rb
@@ -35,7 +35,7 @@ module Gruf
       end
 
       ##
-      # @return [Gruf::Zipkin::Headers]
+      # @return [Gruf::Lightstep::Headers]
       #
       def headers
         @headers ||= Gruf::Lightstep::Headers.new(@active_call)

--- a/lib/gruf/lightstep/version.rb
+++ b/lib/gruf/lightstep/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Lightstep
-    VERSION = '1.2.2.pre'
+    VERSION = '1.3.0.pre'
   end
 end


### PR DESCRIPTION
## What?

- Bump Ruby requirement to 2.6+
- Bump bc-lightstep-ruby dependency to 2.0+
- Explicitly declare gruf requirement in gemspec
- Explicitly declare development deps for gem

Fixes #12 

----

@bigcommerce/oss-maintainers @bigcommerce/ruby @billthompson 