### PR TITLE
Change to racially neutral terminology across library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
+- Move from whitelist -> allowlist in server interceptor
+
 ### 1.3.0
 
 - Bump Ruby requirement to 2.6+
@@ -26,7 +28,7 @@ Changelog for the gruf-lightstep gem.
 
 - First OSS release
 - Explicitly require bc-lightstep-ruby dependency
-- Add option to whitelist request params to lightstep as span tags
+- Add option to allowlist request params to lightstep as span tags
 
 ### 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gruf-lightstep - LightStep tracing for gruf
 
-[![CircleCI](https://circleci.com/gh/bigcommerce/gruf-lightstep/tree/master.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf-lightstep/tree/master) [![Gem Version](https://badge.fury.io/rb/gruf-lightstep.svg)](https://badge.fury.io/rb/gruf-lightstep) [![Inline docs](http://inch-ci.org/github/bigcommerce/gruf-lightstep.svg?branch=master)](http://inch-ci.org/github/bigcommerce/gruf-lightstep)
+[![CircleCI](https://circleci.com/gh/bigcommerce/gruf-lightstep/tree/main.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf-lightstep/tree/main) [![Gem Version](https://badge.fury.io/rb/gruf-lightstep.svg)](https://badge.fury.io/rb/gruf-lightstep) [![Inline docs](http://inch-ci.org/github/bigcommerce/gruf-lightstep.svg?branch=main)](http://inch-ci.org/github/bigcommerce/gruf-lightstep)
 
 Adds LightStep tracing support for [gruf](https://github.com/bigcommerce/gruf) 2.0.0+.
 
@@ -43,11 +43,11 @@ It comes with a few more options as well:
 
 | Option | Description | Default |
 | ------ | ----------- | ------- |
-| whitelist | An array of parameter key names to log to lightstep. E.g. `[uuid kind]` | `[]` |
+| allowlist | An array of parameter key names to log to lightstep. E.g. `[uuid kind]` | `[]` |
 | ignore_methods | An array of method names to ignore from logging. E.g. `['namespace.health.check']` | `[]` |
 
-It's important to maintain a safe whitelist should you decide to log parameters; gruf does no
-parameter sanitization on its own. We also recommend do not whitelist parameters that may contain
+It's important to maintain a safe allowlist should you decide to log parameters; gruf does no
+parameter sanitization on its own. We also recommend do not allowlist parameters that may contain
 very large values (such as binary or json data).
 
 ### Client Interceptors

--- a/spec/gruf/lightstep/server_interceptor_spec.rb
+++ b/spec/gruf/lightstep/server_interceptor_spec.rb
@@ -112,8 +112,8 @@ describe Gruf::Lightstep::ServerInterceptor do
       end
     end
 
-    context 'with request param whitelist' do
-      let(:options) { { whitelist: ['uuid'] } }
+    context 'with request param allowlist' do
+      let(:options) { { allowlist: ['uuid'] } }
       let(:span) { double(:span, set_tag: true) }
 
       it 'should only trace the uuid request param' do


### PR DESCRIPTION
## What?

Terminology within gruf-lightstep should not be racially insensitive or discriminatory. This moves gruf-lightstep away from any racially discriminatory language:

* `whitelist` becomes `allowlist`
* `master` branch will be changed to `main` after this PR is merged.

Note that systems using the whitelist functionality in the server interceptor will need to adjust their reference to the parameter. We are preferring to have that be a forced changed rather than provide an upgrade path, to properly remove the biased language from the library in entirety.

----

@bigcommerce/platform-engineering @bigcommerce/ruby @bigcommerce/oss-maintainers 