### PR TITLE
Ensure error span tag is always set when an exception is raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
+- Ensure `error` span tag is always set when an exception is raised 
 - Move from whitelist -> allowlist in server interceptor
 
 ### 1.3.0

--- a/lib/gruf/lightstep/server_interceptor.rb
+++ b/lib/gruf/lightstep/server_interceptor.rb
@@ -21,6 +21,8 @@ module Gruf
     # Intercepts inbound calls to provide LightStep tracing
     #
     class ServerInterceptor < Gruf::Interceptors::ServerInterceptor
+      DEFAULT_ERROR_CLASSES = %w[GRPC::Unknown GRPC::Internal GRPC::DataLoss GRPC::FailedPrecondition GRPC::Unavailable GRPC::DeadlineExceeded GRPC::Cancelled].freeze
+
       ##
       # Handle the gruf around hook and trace sampled requests
       #
@@ -44,7 +46,7 @@ module Gruf
           begin
             result = yield
           rescue StandardError => e
-            span.set_tag('error', true) if error?(e)
+            span.set_tag('error', error?(e))
             span.set_tag('grpc.error', true)
             span.set_tag('grpc.error_code', code_for(e))
             span.set_tag('grpc.error_class', e.class)
@@ -104,7 +106,7 @@ module Gruf
       # @return [Array]
       #
       def error_classes
-        options.fetch(:error_classes, %w[GRPC::Unknown GRPC::Internal GRPC::DataLoss GRPC::FailedPrecondition GRPC::Unavailable GRPC::DeadlineExceeded GRPC::Cancelled])
+        @error_classes ||= (options.fetch(:error_classes, nil) || DEFAULT_ERROR_CLASSES)
       end
     end
   end

--- a/spec/gruf/lightstep/server_interceptor_spec.rb
+++ b/spec/gruf/lightstep/server_interceptor_spec.rb
@@ -86,7 +86,7 @@ describe Gruf::Lightstep::ServerInterceptor do
         it 'should trace the request as a grpc error but not a span error' do
           expect {
             expect(tracer).to receive(:start_span).once.and_yield(span)
-            expect(span).to_not receive(:set_tag).with('error', true)
+            expect(span).to receive(:set_tag).with('error', false)
             expect(span).to receive(:set_tag).with('grpc.error', true).ordered
             expect(span).to receive(:set_tag).with('grpc.error_code', exception.code).ordered
             expect(span).to receive(:set_tag).with('grpc.error_class', exception.class).ordered
@@ -101,7 +101,7 @@ describe Gruf::Lightstep::ServerInterceptor do
         it 'should trace the request as a non grpc error' do
           expect {
             expect(tracer).to receive(:start_span).once.and_yield(span)
-            expect(span).to_not receive(:set_tag).with('error', true)
+            expect(span).to receive(:set_tag).with('error', false)
             expect(span).to receive(:set_tag).with('grpc.error', true).ordered
             expect(span).to receive(:set_tag).with('grpc.error_code', ::Gruf::Lightstep.default_error_code).ordered
             expect(span).to receive(:set_tag).with('grpc.error_class', exception.class).ordered


### PR DESCRIPTION
https://github.com/bigcommerce/bc-lightstep-ruby/blob/012490caf4c06d1bbfffa804837192d8277f9b10/lib/bigcommerce/lightstep/tracer.rb#L69 is currently swallowing all `GRPC::*` class errors, which prevents the `error_classes` option from being properly enforced here in gruf-lightstep.

This PR sets the `error` tag explicitly, rather than only setting it for errors, and sets the value to `false` if it is not in the `error_classes` set. This allows non-error GRPC status codes (such as `InvalidArgument` or `NotFound`) to not be reported as errors in LightStep, since they are more validation errors rather than application ones.

This will need to be paired with a patch in bc-lightstep-ruby to not set the `error` span tag if it is already explicitly set.

---

@bigcommerce/platform-engineering @bigcommerce/ruby 