### PR TITLE
Remove unnecessarily strict dev dependencies, add bundler 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,21 +37,19 @@ commands:
       - add_ssh_keys
       - checkout
   bundle-install:
+    parameters:
+      gem_cache_key:
+        type: string
+        default: gem-cache-v2
     steps:
-      - run:
-          name: "Install bundler 1.17.3"
-          command: |
-            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler:1.17.3
       - restore_cache:
           keys:
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}
+            - <<parameters.gem_cache_key>>
       - run: bundle check || bundle install --path vendor/bundle
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   rspec-unit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
+- Remove unnecessarily strict dev dependencies
+
 ### 1.5.0
 
 - Add official support for Ruby 3 

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -34,14 +34,13 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
-  spec.add_development_dependency 'bundler-audit', '~> 0.6'
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'pry', '>= 0.13'
   spec.add_development_dependency 'rake', '>= 12.0'
-  spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4'
-  spec.add_development_dependency 'rubocop', '~> 0.82'
-  spec.add_development_dependency 'simplecov', '~> 0.15'
+  spec.add_development_dependency 'rspec', '>= 3.8'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
+  spec.add_development_dependency 'rubocop', '>= 0.82'
+  spec.add_development_dependency 'simplecov', '>= 0.15'
 
   spec.add_runtime_dependency 'bc-lightstep-ruby', '~> 2.2'
   spec.add_runtime_dependency 'gruf', '>= 2.4', '< 3'

--- a/lib/gruf/lightstep/client_interceptor.rb
+++ b/lib/gruf/lightstep/client_interceptor.rb
@@ -44,7 +44,7 @@ module Gruf
         return unless tracer
 
         span = tracer.active_span
-        return unless span&.is_a?(::LightStep::Span)
+        return unless span.is_a?(::LightStep::Span)
 
         span
       end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+bundle install
+bundle exec bundle-audit update
+bundle exec bundle-audit check -v
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec rspec


### PR DESCRIPTION
## What?

* Remove unnecessarily strict development dependencies
* Allow for Bundler 2 support

---

@bigcommerce/ruby @bigcommerce/oss-maintainers 