### PR TITLE
Add support for Ruby 3.2, drop support for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_7:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.7"
   ruby_3_0:
     <<: *ruby_env
     parameters:
@@ -31,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.1"
+  ruby_3_2:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.2"
 commands:
   pre-setup:
     steps:
@@ -54,8 +54,6 @@ commands:
           name: "Bundle install"
           command: |
             export GRPC_RUBY_BUILD_PROCS=<<parameters.grpc_ruby_build_procs>>
-            # due to needing GRPC_RUBY_BUILD_PROCS, we need to explicitly install at least this version
-            gem install grpc -v '>= 1.44.0.pre2' --verbose --no-document
             bundle config set --local path 'vendor/bundle'
             bundle lock --add-platform x86_64-linux
             bundle check || bundle install
@@ -101,7 +99,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -111,7 +109,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -121,7 +119,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -129,17 +127,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
-      - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
-      - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
   ruby_3_0:
     jobs:
       - bundle-audit:
@@ -162,3 +149,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_1-rspec"
           e: "ruby_3_1"
+  ruby_3_2:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_2-bundle_audit"
+          e: "ruby_3_2"
+      - rubocop:
+          name: "ruby-3_2-rubocop"
+          e: "ruby_3_2"
+      - rspec-unit:
+          name: "ruby-3_2-rspec"
+          e: "ruby_3_2"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bigcommerce/ruby
+* @bigcommerce/oss-maintainers

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## What? Why?
+
+
+## How was it tested?
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   Exclude:
     - spec/**/*
     - .bundle/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
+- Add support for Ruby 3.2
+- Drop support for Ruby 2.7 (EOL March 2023)
+
 ### 1.6.0
 
 - Add support for Ruby 3.1

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-lightstep.gemspec']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.7'
+  spec.required_ruby_version = '>= 3.0', '< 4'
 
   spec.add_development_dependency 'bundler-audit', '>= 0.6'
   spec.add_development_dependency 'pry', '>= 0.13'


### PR DESCRIPTION
## What? Why?

* Add tested support for Ruby 3.2
* Drops support for Ruby 2.7 (EOL March 2023)

## How was it tested?

rspec, local