### PR TITLE
Update ot-tracer-sampled to use 'true' and 'false' instead of '0' and '1'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
+- Use default value of `'true'` for the `ot-tracer-sampled` value in the client interceptor instead of `'1'`
+
 ### 1.7.0
 
 - Add support for Ruby 3.2

--- a/lib/gruf/lightstep/client_interceptor.rb
+++ b/lib/gruf/lightstep/client_interceptor.rb
@@ -28,7 +28,7 @@ module Gruf
           logger.debug "[gruf-lightstep] Injecting current active span #{span_data[:span_guid]} into outbound request context for #{request_context.method_name}"
           request_context.metadata['ot-tracer-spanid'] = span_data[:span_guid].to_s
           request_context.metadata['ot-tracer-traceid'] = span_data[:trace_guid].to_s
-          request_context.metadata['ot-tracer-sampled'] = '1'
+          request_context.metadata['ot-tracer-sampled'] = 'true'
         end
 
         yield


### PR DESCRIPTION
## What? Why?
Update `ot-tracer-sampled` value to send `'true'` instead of `'1'` in the client interceptor.

`'0'` and `'1'` _are_ valid values for ruby as per https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/bde58e0c7c7e6a820ef68dd3e382bb34c9cf7f54/propagator/ottrace/README.md?plain=1#L12 but every other language lists only `'true'` and `'false'`. The intention is that this plays nicer with other languages when passing through these tracing values.

## How was it tested?
Ran the specs...
