### PR TITLE
Add Ruby 3.4 support, drop EOL Ruby 3.0/3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,18 +13,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_3_0:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.0"
-  ruby_3_1:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "3.1"
   ruby_3_2:
     <<: *ruby_env
     parameters:
@@ -37,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.3"
+  ruby_3_4:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.4"
 
 commands:
   pre-setup:
@@ -106,7 +100,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -116,7 +110,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -126,7 +120,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_3_0"
+        default: "ruby_3_2"
     steps:
       - pre-setup
       - bundle-install
@@ -134,28 +128,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_3_0:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_0-bundle_audit"
-          e: "ruby_3_0"
-      - rubocop:
-          name: "ruby-3_0-rubocop"
-          e: "ruby_3_0"
-      - rspec-unit:
-          name: "ruby-3_0-rspec"
-          e: "ruby_3_0"
-  ruby_3_1:
-    jobs:
-      - bundle-audit:
-          name: "ruby-3_1-bundle_audit"
-          e: "ruby_3_1"
-      - rubocop:
-          name: "ruby-3_1-rubocop"
-          e: "ruby_3_1"
-      - rspec-unit:
-          name: "ruby-3_1-rspec"
-          e: "ruby_3_1"
   ruby_3_2:
     jobs:
       - bundle-audit:
@@ -178,3 +150,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_3-rspec"
           e: "ruby_3_3"
+  ruby_3_4:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_4-bundle_audit"
+          e: "ruby_3_4"
+      - rubocop:
+          name: "ruby-3_4-rubocop"
+          e: "ruby_3_4"
+      - rspec-unit:
+          name: "ruby-3_4-rspec"
+          e: "ruby_3_4"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @bigcommerce/ruby
-* @bigcommerce/oss-maintainers
+* @bigcommerce/ruby @bigcommerce/oss-maintainers

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
   Exclude:
     - spec/**/*
     - .bundle/**/*
@@ -7,6 +7,11 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
     - log/**/*
+plugins:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+  - rubocop-thread_safety
 
 # Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog for the gruf-lightstep gem.
 
 ### Pending Release
 
-- Add CI suite for Ruby 3.3
+- Add support for Ruby 3.3, 3.4
+- Drop support for Ruby 3.0, 3.1 (EOL)
 
 ### 1.7.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ gem 'rake', '>= 12.0'
 gem 'rspec', '>= 3.8'
 gem 'rspec_junit_formatter', '>= 0.4'
 gem 'rubocop', '>= 0.82'
+gem 'rubocop-performance'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'
+gem 'rubocop-thread_safety'
 gem 'simplecov', '>= 0.15'
 
 gemspec

--- a/gruf-lightstep.gemspec
+++ b/gruf-lightstep.gemspec
@@ -32,10 +32,10 @@ Gem::Specification.new do |spec|
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-lightstep.gemspec']
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 3.0', '< 4'
+  spec.required_ruby_version = '>= 3.2', '< 4'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_runtime_dependency 'bc-lightstep-ruby', '~> 2.2'
-  spec.add_runtime_dependency 'gruf', '>= 2.4', '< 3'
-  spec.add_runtime_dependency 'rake', '>= 12'
+  spec.add_dependency 'bc-lightstep-ruby', '>= 2.8'
+  spec.add_dependency 'gruf', '>= 2.4', '< 3'
+  spec.add_dependency 'rake', '>= 12'
 end

--- a/lib/gruf/lightstep/version.rb
+++ b/lib/gruf/lightstep/version.rb
@@ -17,6 +17,6 @@
 #
 module Gruf
   module Lightstep
-    VERSION = '1.7.2.pre'
+    VERSION = '1.8.0.pre'
   end
 end


### PR DESCRIPTION
## What? Why?

- Add support for Ruby 3.3, 3.4
- Drop support for Ruby 3.0, 3.1 (EOL)
- Fix CODEOWNERS file

## How was it tested?

Unit suite should pass.